### PR TITLE
TECHX-539 Add version prefix support

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,10 @@
 name: 'Validate NPM Package Version'
 description: 'Ensure that the package version you want to publish is available'
+inputs:
+  version-prefix:
+    description: 'A prefix that will be prepended to the version.  E.g. in v1.0.0 the prefix is "v"'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -10,6 +15,8 @@ runs:
     - id: version-check
       run: ${{ github.action_path }}/entrypoint.sh
       shell: bash
+      env:
+        PREFIX: ${{ inputs.version-prefix }}
     - if: ${{ failure() }}
       run: echo "The git tag ${{ steps.version-check.outputs.version }} already exists.  Did You forget to increment the version number in package.json?"
       shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Store the version number
-version=$(jq .version package.json | sed 's/"//g')
+version=$PREFIX$(jq .version package.json | sed 's/"//g')
 echo "::set-output name=version::$version"
 
 # See if tag exists for this version number


### PR DESCRIPTION
Many packages use a version prefix such as the “v” in v1.0.0 and validate-npm-package-version now supports prefixes in order to be compatible with those packages.